### PR TITLE
Add property to en-/disable oauth2

### DIFF
--- a/oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthConfiguration.java
+++ b/oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthConfiguration.java
@@ -40,4 +40,9 @@ public interface OauthConfiguration {
      */
     @Nullable
     String getClientSecret();
+
+    /**
+     * @return Whether the component is enabled
+     */
+    default boolean isEnabled() { return false; }
 }

--- a/oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthConfigurationProperties.java
+++ b/oauth2/src/main/java/io/micronaut/security/oauth2/configuration/OauthConfigurationProperties.java
@@ -18,6 +18,7 @@ package io.micronaut.security.oauth2.configuration;
 
 import io.micronaut.context.annotation.ConfigurationProperties;
 import io.micronaut.context.annotation.Requires;
+import io.micronaut.core.util.StringUtils;
 import io.micronaut.security.config.SecurityConfigurationProperties;
 
 import javax.annotation.Nonnull;
@@ -29,7 +30,7 @@ import javax.annotation.Nullable;
  * @author Sergio del Amo
  * @since 1.0.0
  */
-@Requires(property = OauthConfigurationProperties.PREFIX + ".client-id")
+@Requires(property = OauthConfigurationProperties.PREFIX + ".enabled", value = StringUtils.TRUE)
 @ConfigurationProperties(OauthConfigurationProperties.PREFIX)
 public class OauthConfigurationProperties implements OauthConfiguration {
     public static final String PREFIX = SecurityConfigurationProperties.PREFIX + ".oauth2";

--- a/oauth2/src/test/groovy/io/micronaut/security/oauth2/configuration/OauthConfigurationSpec.groovy
+++ b/oauth2/src/test/groovy/io/micronaut/security/oauth2/configuration/OauthConfigurationSpec.groovy
@@ -26,12 +26,12 @@ class OauthConfigurationSpec extends Specification {
         context.close()
     }
 
-    void "OauthConfiguration is enabled if client-id is present"() {
+    void "OauthConfiguration is enabled if enabled is set to true"() {
         given:
         ApplicationContext context = ApplicationContext.run([
                 (SPEC_NAME_PROPERTY): getClass().simpleName,
                 'micronaut.security.enabled': true,
-                'micronaut.security.oauth2.client-id': 'YYYY',
+                'micronaut.security.oauth2.enabled': true,
         ], Environment.TEST)
 
         when:

--- a/oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoints/AuthorizationCodeControllerDisableSpec.groovy
+++ b/oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoints/AuthorizationCodeControllerDisableSpec.groovy
@@ -18,6 +18,7 @@ class AuthorizationCodeControllerDisableSpec extends Specification {
     Map<String, Object> config = [
             (SPEC_NAME)                                   : getClass().simpleName,
             'micronaut.security.enabled'                  : true,
+            'micronaut.security.oauth2.enabled'           : true,
             'micronaut.security.oauth2.client-id'         : 'XXX',
             'micronaut.security.oauth2.token.redirect-uri': 'http://localhost:8080',
             'micronaut.security.oauth2.token.url'         : 'http://localhost:8080',

--- a/oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoints/AuthorizationCodeControllerErrorResponseSpec.groovy
+++ b/oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoints/AuthorizationCodeControllerErrorResponseSpec.groovy
@@ -28,6 +28,7 @@ class AuthorizationCodeControllerErrorResponseSpec extends Specification {
             'micronaut.server.port': serverPort,
             'micronaut.security.enabled': true,
             'micronaut.security.token.jwt.enabled': true,
+            'micronaut.security.oauth2.enabled': true,
             'micronaut.security.oauth2.client-id': 'XXX',
             'micronaut.security.oauth2.openid.openid-issuer': "http://localhost:$serverPort",
             'micronaut.security.oauth2.token.redirect-uri': "http://localhost:$serverPort",

--- a/oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoints/AuthorizationCodeControllerPathSpec.groovy
+++ b/oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoints/AuthorizationCodeControllerPathSpec.groovy
@@ -25,6 +25,7 @@ class AuthorizationCodeControllerPathSpec extends Specification {
             (SPEC_NAME_PROPERTY): getClass().simpleName,
             'micronaut.security.enabled': true,
             'micronaut.security.token.jwt.enabled': true,
+            'micronaut.security.oauth2.enabled': true,
             'micronaut.security.oauth2.client-id': 'XXX',
             'micronaut.security.oauth2.token.redirect-uri': 'http://localhost:8080',
             'micronaut.security.oauth2.token.url': 'http://localhost:8080',

--- a/oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoints/JwtValidatorReplacement.groovy
+++ b/oauth2/src/test/groovy/io/micronaut/security/oauth2/endpoints/JwtValidatorReplacement.groovy
@@ -7,6 +7,7 @@ import io.micronaut.security.authentication.DefaultAuthentication
 import io.micronaut.security.token.jwt.encryption.EncryptionConfiguration
 import io.micronaut.security.token.jwt.signature.SignatureConfiguration
 import io.micronaut.security.token.jwt.validator.GenericJwtClaimsValidator
+import io.micronaut.security.token.jwt.validator.JwtAuthenticationFactory
 import io.micronaut.security.token.jwt.validator.JwtClaimsValidator
 import io.micronaut.security.token.jwt.validator.JwtTokenValidator
 
@@ -16,8 +17,9 @@ import javax.inject.Singleton
 @Singleton
 @Requires(property = 'spec.name', value='AuthorizationCodeControllerSpec')
 class JwtValidatorReplacement extends JwtTokenValidator {
-    JwtValidatorReplacement(Collection<SignatureConfiguration> signatureConfigurations, Collection<EncryptionConfiguration> encryptionConfigurations, Collection<GenericJwtClaimsValidator> genericJwtClaimsValidators) {
-        super(signatureConfigurations, encryptionConfigurations, genericJwtClaimsValidators)
+
+    JwtValidatorReplacement(Collection<SignatureConfiguration> signatureConfigurations, Collection<EncryptionConfiguration> encryptionConfigurations, Collection<GenericJwtClaimsValidator> genericJwtClaimsValidators, JwtAuthenticationFactory jwtAuthenticationFactory) {
+        super(signatureConfigurations, encryptionConfigurations, genericJwtClaimsValidators, jwtAuthenticationFactory)
     }
 
     Optional<Authentication> authenticationIfValidJwtSignatureAndClaims(String token, Collection<? extends JwtClaimsValidator> claimsValidators) {

--- a/oauth2/src/test/groovy/io/micronaut/security/oauth2/grants/password/GrantTypePasswordAuthenticationProviderSpec.groovy
+++ b/oauth2/src/test/groovy/io/micronaut/security/oauth2/grants/password/GrantTypePasswordAuthenticationProviderSpec.groovy
@@ -12,6 +12,7 @@ class GrantTypePasswordAuthenticationProviderSpec extends Specification {
     Map<String, Object> conf = [
             'micronaut.security.enabled': true,
             'micronaut.security.token.jwt.enabled': true,
+            'micronaut.security.oauth2.enabled': true,
             'micronaut.security.oauth2.client-id': 'XXXXX',
             'micronaut.security.oauth2.client-secret': 'YYYYY',
     ] as Map<String, Object>

--- a/oauth2/src/test/groovy/io/micronaut/security/oauth2/grants/password/passwordflow/PasswordFlowSpec.groovy
+++ b/oauth2/src/test/groovy/io/micronaut/security/oauth2/grants/password/passwordflow/PasswordFlowSpec.groovy
@@ -46,6 +46,7 @@ class PasswordFlowSpec extends Specification {
         Map<String, Object> conf = [
                 'spec.name': 'passwordFlow',
                 'micronaut.security.enabled': true,
+                'micronaut.security.oauth2.enabled': true,
                 'micronaut.security.oauth2.client-id': 'XXXX',
                 'micronaut.security.oauth2.client-secret': 'YYYY',
                 'micronaut.security.oauth2.issuer': mockHttpServerUrl,

--- a/oauth2/src/test/groovy/io/micronaut/security/oauth2/openid/endpoints/authorization/DefaultAuthorizationRedirectUrlProviderSpec.groovy
+++ b/oauth2/src/test/groovy/io/micronaut/security/oauth2/openid/endpoints/authorization/DefaultAuthorizationRedirectUrlProviderSpec.groovy
@@ -33,6 +33,7 @@ class DefaultAuthorizationRedirectUrlProviderSpec extends Specification {
         ApplicationContext context = ApplicationContext.run([
             (SPEC_NAME_PROPERTY)                            : getClass().simpleName,
             'micronaut.security.enabled'                    : true,
+            'micronaut.security.oauth2.enabled'             : true,
             'micronaut.security.oauth2.client-id'           : 'XXXX',
             'micronaut.security.oauth2.issuer': issuer
         ], Environment.TEST)

--- a/oauth2/src/test/groovy/io/micronaut/security/oauth2/openid/endpoints/endsession/EndSessionUrlProviderSpec.groovy
+++ b/oauth2/src/test/groovy/io/micronaut/security/oauth2/openid/endpoints/endsession/EndSessionUrlProviderSpec.groovy
@@ -34,6 +34,7 @@ class EndSessionUrlProviderSpec extends Specification {
         ApplicationContext context = ApplicationContext.run([
                 (SPEC_NAME_PROPERTY)                            : getClass().simpleName,
                 'micronaut.security.enabled'                    : true,
+                'micronaut.security.oauth2.enabled'             : true,
                 'micronaut.security.oauth2.client-id'           : 'XXX',
                 'micronaut.security.oauth2.issuer': issuer
         ], Environment.TEST)

--- a/oauth2/src/test/groovy/io/micronaut/security/oauth2/openid/endpoints/token/AuthorizationCodeGrantRequestGeneratorSpec.groovy
+++ b/oauth2/src/test/groovy/io/micronaut/security/oauth2/openid/endpoints/token/AuthorizationCodeGrantRequestGeneratorSpec.groovy
@@ -34,6 +34,7 @@ class AuthorizationCodeGrantRequestGeneratorSpec extends Specification {
         ApplicationContext context = ApplicationContext.run([
                 (SPEC_NAME_PROPERTY)                            : getClass().simpleName,
                 'micronaut.security.enabled'                    : true,
+                'micronaut.security.oauth2.enabled'             : true,
                 'micronaut.security.oauth2.client-id'           : 'XXXX',
                 'micronaut.security.oauth2.client-secret'       : 'YYYY',
                 'micronaut.security.oauth2.issuer': issuer,


### PR DESCRIPTION
Prior config used `client-id` as toggle to en- / disable *oauth2*. It was impossible to get rid of oauth for testing when `application.yml` contained an oauth2 config.